### PR TITLE
run in docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:latest
+FROM node:16 as installer
 
 
 RUN apt-get update
@@ -13,4 +13,8 @@ COPY . .
 RUN make && make install-su
 
 RUN echo "Running!"
+
+
+FROM installer
+
 ENTRYPOINT ["tail", "-f", "/dev/null"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM ubuntu:latest
+
+
+RUN apt-get update
+RUN apt-get -y install ffmpeg ruby make gcc
+
+RUN mkdir /usr/src/app
+
+WORKDIR /usr/src/app
+
+COPY . .
+
+RUN make && make install-su
+
+RUN echo "Running!"
+ENTRYPOINT ["tail", "-f", "/dev/null"]

--- a/Makefile
+++ b/Makefile
@@ -69,6 +69,14 @@ install:
 	sudo cp olaf.rb /usr/local/bin/olaf
 	sudo chmod +x /usr/local/bin/olaf
 
+#installs olaf as root user
+install-su:
+	mkdir -p ~/.olaf/db/
+	cp bin/olaf_c /usr/local/bin/olaf_c
+	chmod +x /usr/local/bin/olaf_c
+	cp olaf.rb /usr/local/bin/olaf
+	chmod +x /usr/local/bin/olaf
+
 #removes all installed files
 uninstall:
 	rm -r ~/.olaf

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,5 +4,3 @@ services:
     build:
       context: .
       dockerfile: ./Dockerfile
-    env_file:
-      - docker.env

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,8 @@
+version: '3.9'
+services:
+  service:
+    build:
+      context: .
+      dockerfile: ./Dockerfile
+    env_file:
+      - docker.env


### PR DESCRIPTION
- Add a dockerfile and a make instruction to run Olaf in a docker container
- remove useless env file

With this you can run olaf just with docker-compose up (no volume though). 

It makes it handy to test the program without installing dependencies.
